### PR TITLE
Fix for '%k' and requested change to 'formatAgo'

### DIFF
--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -157,9 +157,9 @@ var formatters = {
     },
 
     'k': function(d, locale) {
-        var day = d.getDate();
-        if (day in locale.daySuffixes) {
-            return locale.daySuffixes[day];
+        var modDay = d.getDate() % 10;
+        if (modDay in locale.daySuffixes) {
+            return locale.daySuffixes[modDay];
         } else {
             return locale.daySuffixes[4];
         }

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -220,8 +220,8 @@ exports.formatAgo = function(d, timezone, baseTime, locale) {
     } else if (delta < week) {
         return exports.format(d, '%A at %i:%M%P', timezone, locale);
     } else if (d.getYear() == baseTime.getYear()) {
-        return exports.format(d, '%B%e%k at %i:%M%P', timezone, locale);
+        return exports.format(d, '%B %e%k at %i:%M%P', timezone, locale);
     } else {
-        return exports.format(d, '%B%e%k, %Y at %i:%M%P', timezone, locale);
+        return exports.format(d, '%B %e%k, %Y at %i:%M%P', timezone, locale);
     }
 };


### PR DESCRIPTION
Hi Joe,

Thanks for the module. The '%k' fix is obvious, I think. 

The other change (formatAgo) is debatable. AFAIK strftime (or Python's datetime, or whereever you are basing your codes) doesn't have a "day of the month without leading zeros or spaces" code -- which is the format code that should be used in this case.

Cheers,
Trent
