### PR TITLE
set default timezone for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 default: test
 
-test: 
-	vows test/*-test.js
+# Pitcairn is handy place where is Pacific Standard Time whole year
+test:
+	TZ=Pacific/Pitcairn vows test/*-test.js
 
 .PHONY: test

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -11,11 +11,11 @@ var locales = {
         ampm: {'AM': 'AM', 'PM': 'PM'},
 
         daySuffixes: {1: 'st', 2: 'nd', 3: 'rd', 4: 'th'},
-        
+
         dateTimeFormat: '%a %d %b %Y %T %Z',
         dateFormat: '%d/%m/%y',
         timeFormat: '%T',
-        
+
         secondAgo: 'a second ago',
         secondsAgo: '%t seconds ago',
         minuteAgo: 'a minute ago',
@@ -158,7 +158,7 @@ var formatters = {
     '%': function(d, locale) {
         return '%';
     },
-    
+
     // NON-STANDARD ADDITIONS
     'i': function(d, locale) {
         var h = d.getHours();
@@ -178,7 +178,7 @@ var formatters = {
 
 function leadingZero(n, leading) {
     return n >= 10 ? n : (leading ? leading : '0')+n;
-}   
+}
 
 // *************************************************************************************************
 
@@ -202,7 +202,7 @@ exports.format = function(d, format, timezone, locale) {
         }
     }
     return format;
-        
+
     // for (var i = 0; i < separated.length; ++i) {
     //     var part = separated[i];
     //     if (part) {

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -173,11 +173,27 @@ var formatters = {
         } else {
             return locale.daySuffixes[4];
         }
+    },
+
+    'l': function(d, locale) {
+        return d.getMilliseconds();
+    },
+
+    'L': function(d, locale) {
+        return leadingZeroes(d.getMilliseconds(), 3);
     }
 };
 
 function leadingZero(n, leading) {
     return n >= 10 ? n : (leading ? leading : '0')+n;
+}
+
+function leadingZeroes(n, digits) {
+    n += ''; // convert it into string
+    while (n.length < digits) {
+        n = '0' + n;
+    }
+    return n;
 }
 
 // *************************************************************************************************

--- a/test/datetime-test.js
+++ b/test/datetime-test.js
@@ -229,7 +229,7 @@ vows.describe('datetime basics').addBatch({
         },
     },
 
-    'A time': {
+    'A date': {
         topic: new Date('March 5, 2008'),
 
         'formatted with hyphens': function(topic) {
@@ -237,7 +237,7 @@ vows.describe('datetime basics').addBatch({
         },
     },
 
-    'A time': {
+    'A time in past': {
         topic: new Date('March 5, 2008 3:30 pm'),
 
         'at singular seconds ago': function(topic) {
@@ -277,16 +277,16 @@ vows.describe('datetime basics').addBatch({
 
         'at a week ago': function(topic) {
             var base = new Date('March 13, 2008 5:45 pm');
-            assert.equal(datetime.formatAgo(topic, null, base), 'March 5th at 3:30pm');
+            assert.equal(datetime.formatAgo(topic, null, base), 'March  5th at 3:30pm');
         },
 
         'at a year ago': function(topic) {
             var base = new Date('March 13, 2009 5:45 pm');
-            assert.equal(datetime.formatAgo(topic, null, base), 'March 5th, 2008 at 3:30pm');
+            assert.equal(datetime.formatAgo(topic, null, base), 'March  5th, 2008 at 3:30pm');
         },
     },
 
-    'A time': {
+    'A time in future': {
         topic: new Date('March 5, 2008 3:30 pm'),
 
         'in singular seconds': function(topic) {

--- a/test/datetime-test.js
+++ b/test/datetime-test.js
@@ -189,6 +189,34 @@ vows.describe('datetime basics').addBatch({
         },
     },
 
+    'A time with 1 to 9 milliseconds': {
+        topic: new Date(0, 0, 0, 0, 0, 0, 3),
+
+        'with %l': function (topic) {
+            assert.equal(datetime.format(topic, '%l'), '3');
+        },
+
+        'with %L': function (topic) {
+            assert.equal(datetime.format(topic, '%L'), '003');
+        },
+    },
+
+    'A time with 10 to 99 milliseconds': {
+        topic: new Date(0, 0, 0, 0, 0, 0, 42),
+
+        'with %L': function (topic) {
+            assert.equal(datetime.format(topic, '%L'), '042');
+        },
+    },
+
+    'A time with 100 to 999 milliseconds': {
+        topic: new Date(0, 0, 0, 0, 0, 0, 256),
+
+        'with %L': function (topic) {
+            assert.equal(datetime.format(topic, '%L'), '256');
+        },
+    },
+
     'A day on the first': {
         topic: new Date('March 1, 2008'),
 


### PR DESCRIPTION
Hi,

I added milliseconds support into format, I chose letter "L" for it - it was free, and I had no better letter for it.

tests were failing for me, my computer has default timezone Europe/Prague (CET).
Setting TZ variable to "America/Los_Angeles" also does not work because half a year, the timezone abbreviation is PDT, not PST.
Luckily, Pacific/Pitcairn solves the problem, there is PST all the year.

Jan
