### PR TITLE
Fix %z to format according to RFC 3339

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+BIN = ./node_modules/.bin
 default: test
 
 test: 
-	vows test/*-test.js
+	$(BIN)/vows test/*-test.js
 
 .PHONY: test

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -150,7 +150,7 @@ var formatters = {
         var offset = d.getTimezoneOffset();
         var hour = leadingZero(Math.round(Math.abs(offset / 60)));
         var min = leadingZero(offset % 60);
-        return (offset > 0 ? '-' : '+') + hour + min;
+        return (offset > 0 ? '-' : '+') + hour + ':' + min;
     },
     'Z': function(d, locale) {
         return d.toString().replace(/^.*\(([^)]+)\)$/, '$1');

--- a/test/datetime-test.js
+++ b/test/datetime-test.js
@@ -2,9 +2,7 @@ var path = require('path'),
     assert = require('assert'),
     vows = require('vows');
 
-require.paths.unshift(path.join(__dirname, '..', 'lib'));
-
-var datetime = require('datetime');
+var datetime = require('../lib/datetime');
 
 // *************************************************************************************************
 
@@ -141,7 +139,7 @@ vows.describe('datetime basics').addBatch({
         },
 
         'with %z': function(topic) {
-            assert.equal(datetime.format(topic, '%z'), '-0800');
+            assert.equal(datetime.format(topic, '%z'), '-08:00');
         },
 
         'with %Z': function(topic) {


### PR DESCRIPTION
Add missin ':' delim between hours and minutes. See examples
at http://tools.ietf.org/html/rfc3339#section-5.8
